### PR TITLE
Adding "header" argument to override the forwarding header.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+  * Adding "header" argument to override the forwarding header.
 
 0.103060 -- Mon Nov 01 19:16:50 CDT 2010
   * Initial Release

--- a/lib/Plack/Middleware/XForwardedFor.pm
+++ b/lib/Plack/Middleware/XForwardedFor.pm
@@ -4,7 +4,7 @@ package Plack::Middleware::XForwardedFor;
 use strict;
 use warnings;
 use parent qw(Plack::Middleware);
-use Plack::Util::Accessor qw( trust );
+use Plack::Util::Accessor qw( trust header );
 use Regexp::Common qw /net/;
 use Net::Netmask;
 
@@ -15,12 +15,21 @@ sub prepare_app {
     my @trust = map { Net::Netmask->new($_) } ref($trust) ? @$trust : ($trust);
     $self->trust(\@trust);
   }
+  if (my $header = $self->header) {
+    $header = uc $header;
+    $header = "HTTP_$header" unless $header =~ m/HTTP_/i;
+    $header =~ s/-/_/g;
+    $self->header($header);
+  }
+  else {
+    $self->header('HTTP_X_FORWARDED_FOR') unless $self->header();
+  }
 }
 
 sub call {
   my ($self, $env) = @_;
 
-  my @forward = ($env->{HTTP_X_FORWARDED_FOR} || '') =~ /\b($RE{net}{IPv4})\b/g;
+  my @forward = ($env->{ $self->header() } || '') =~ /\b($RE{net}{IPv4})\b/g;
 
   if (@forward) {
     my $addr = $env->{REMOTE_ADDR};
@@ -76,6 +85,12 @@ first IP in the C<X-Forwarded-For> header.
 If given, it should be a list of IPs or Netmasks that can be trusted. Starting with the IP
 of the client in C<REMOTE_ADDR> then the IPs in the C<X-Forwarded-For> header from right to left.
 The first untrusted IP found is set to be C<REMOTE_ADDR>
+
+=item header
+
+If you'd like to check for a header other than C<X-Forwarded-For>, then use this parameter.
+It will automatically clean up the header name to match what's in C<$env>, so
+both C<X-Your-Forwarding-Header> and C<HTTP_X_YOUR_FORWARDING_HEADER> are valid.
 
 =back
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -40,10 +40,40 @@ my @tests = (
     __trust              => ["127.0.0.1", "9.8/16"],
     __expect             => "10.55.1.2",
   },
+
+  # The following tests check the functionality to override "header".
+  { REMOTE_ADDR          => "1.2.3.4",
+    HTTP_X_FORWARDED_FOR => "9.8.7.6",
+    __expect             => "1.2.3.4",
+    __header             => 'HTTP_OTHER_HEADER',
+  },
+  { REMOTE_ADDR          => "1.2.3.4",
+    HTTP_OTHER_HEADER    => "9.8.7.6",
+    __expect             => "9.8.7.6",
+    __header             => 'HTTP_OTHER_HEADER',
+  },
+  { REMOTE_ADDR          => "1.2.3.4",
+    HTTP_OTHER_HEADER    => "5.6.7.8",
+    HTTP_X_FORWARDED_FOR => "9.10.11.12",
+    __expect             => "5.6.7.8",
+    __header             => 'HTTP_OTHER_HEADER',
+  },
+
+  # Also checking the code that fixes the header name.
+  { REMOTE_ADDR          => "1.2.3.4",
+    HTTP_OTHER_HEADER    => "9.8.7.6",
+    __expect             => "9.8.7.6",
+    __header             => 'Other-Header',
+  },
+  { REMOTE_ADDR          => "1.2.3.4",
+    HTTP_X_FORWARDED_FOR => "9.8.7.6",
+    __expect             => "9.8.7.6",
+    __header             => 'X-Forwarded-For',
+  },
 );
 
 foreach my $env (@tests) {
-  build_handler(trust => $env->{__trust})->($env);
+  build_handler(trust => $env->{__trust}, header => $env->{__header})->($env);
 }
 
 done_testing();


### PR DESCRIPTION
Hello!

At $WORK, for some crazy reason our haproxy servers use a forwarding header other than `X-Forwarded-For`. So I've modified this package to let the user set the header.

I'm a little uncertain about the regex stuff I added to convert `X-Whatever` to `HTTP_X_WHATEVER`. It should work, but I feel like there's probably something out there that will just take care of it for me.

Let me know if there's anything you'd like me to change.

Cheers!