### PR TITLE
Handle when REMOTE_ADDR is undef, such as when using Unix socket

### DIFF
--- a/lib/Plack/Middleware/XForwardedFor.pm
+++ b/lib/Plack/Middleware/XForwardedFor.pm
@@ -24,7 +24,7 @@ sub call {
     (split(/,\s*/, ($env->{HTTP_X_FORWARDED_FOR} || '')));
 
   if (@forward) {
-    my $addr = $env->{REMOTE_ADDR};
+    my $addr = $env->{REMOTE_ADDR} || '';
     $addr =~ s/^::ffff://;
 
     if (my $trust = $self->trust) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -66,4 +66,21 @@ foreach my $env (@tests) {
   build_handler(trust => $env->{__trust})->($env);
 }
 
+ok(
+  eval {
+    local $SIG{__WARN__} = sub {
+      print STDERR $_[0];
+      die "Warning: " . $_[0];
+    };
+
+    build_handler()->(
+      { REMOTE_ADDR          => undef,
+        HTTP_X_FORWARDED_FOR => "9.8.7.6",
+        __expect             => "9.8.7.6",
+      }
+    )
+  },
+  'No warning when REMOTE_ADDR is undef, such as when a Unix socket is used'
+);
+
 done_testing();


### PR DESCRIPTION
`REMOTE_ADDR` in the PSGI environment will be `undef` when the PSGI app is run using a Unix socket. While the module does work correctly without this change, a warning is emitted on every request, which causes lots of noise in the PSGI logs. Please consider merging this, and let me know if I should make any changes. Thank you!